### PR TITLE
fix: use PAT for release-please to trigger release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
## Summary
- Use `RELEASE_PLEASE_TOKEN` (PAT) instead of `GITHUB_TOKEN` in release-please workflow
- `GITHUB_TOKEN`-created tags don't trigger other workflows by design, which is why the Release workflow wasn't firing after merging release PRs

## Setup required
1. Create a fine-grained PAT with **Contents: Read and write** permission scoped to this repo
2. Add it as a repo secret named `RELEASE_PLEASE_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)