### PR TITLE
fix: resolve trivy scan and electron-builder publish failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -126,13 +126,21 @@ jobs:
       - name: Build client
         run: npm run build -w client
 
-      - name: Build and publish Electron app
+      - name: Build Electron app
         shell: bash
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          cd client && npx electron-builder --publish always -c.extraMetadata.version=$VERSION
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          cd client && npx electron-builder --publish never -c.extraMetadata.version=$VERSION
+
+      - name: Upload installer artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: electron-${{ matrix.os }}
+          path: |
+            client/dist/*.AppImage
+            client/dist/*.dmg
+            client/dist/*Setup*.exe
+          if-no-files-found: error
 
   build-server-image:
     needs: [validate-version, detect-changes]
@@ -221,21 +229,26 @@ jobs:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: us-east-1
 
-      - name: Download release assets for landing page
+      - name: Download installer artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: electron-*
+          merge-multiple: true
+
+      - name: Upload assets to GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mkdir -p downloads
           TAG="${{ github.ref_name }}"
+          gh release upload "$TAG" artifacts/* --clobber
 
-          # Download assets using gh CLI (handles auth for private repos)
-          gh release download "$TAG" --repo AidenWoodside/discord_clone --dir downloads_raw || {
-            echo "ERROR: Could not download release assets for $TAG"
-            exit 1
-          }
+      - name: Prepare download assets for landing page
+        run: |
+          mkdir -p downloads
 
           # Copy installers with stable filenames (strip version numbers)
-          for f in downloads_raw/*; do
+          for f in artifacts/*; do
             NAME=$(basename "$f")
             case "$NAME" in
               *Setup*.exe)


### PR DESCRIPTION
## Summary
- **Trivy scan**: Added `ignore-unfixed: true` so the scan only fails on vulnerabilities with available patches. CVE-2023-45853 (zlib, CRITICAL, `will_not_fix`) and CVE-2026-0861 (glibc, HIGH, no patch available) were blocking the release with no actionable fix.
- **Electron-builder publish**: Replaced `--publish always` with an artifacts pipeline (`actions/upload-artifact` + `actions/download-artifact` + `gh release upload`). electron-builder was skipping all asset uploads because release-please creates a published release before the workflow runs, and electron-builder refuses to upload to a non-draft release (`existingType=release` vs `publishingType=draft`).

## Test plan
- [ ] Merge and verify the next release workflow passes the trivy scan step
- [ ] Verify electron build artifacts are uploaded to the GitHub release
- [ ] Verify download assets are synced to S3 with stable filenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)