### PR TITLE
fix: add AWS CLI v2 path to SSM commands and guard webhook URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,7 +305,7 @@ jobs:
             --instance-ids "${{ secrets.EC2_INSTANCE_ID }}" \
             --document-name "AWS-RunShellScript" \
             --timeout-seconds 60 \
-            --parameters 'commands=["export HOME=/root && export PATH=$PATH:/usr/local/bin:/usr/bin && git config --global --add safe.directory /home/ubuntu/discord_clone && cd /home/ubuntu/discord_clone && git fetch origin main && git checkout origin/main -- docker-compose.yml docker/ scripts/ && aws s3 sync s3://discord-clone-assets-966917019849/ data/downloads/"]' \
+            --parameters 'commands=["export HOME=/root && export PATH=$PATH:/usr/local/bin:/usr/bin:/usr/local/aws-cli/v2/current/bin && git config --global --add safe.directory /home/ubuntu/discord_clone && cd /home/ubuntu/discord_clone && git fetch origin main && git checkout origin/main -- docker-compose.yml docker/ scripts/ && aws s3 sync s3://discord-clone-assets-966917019849/ data/downloads/"]' \
             --query "Command.CommandId" --output text)
 
           for i in $(seq 1 15); do
@@ -329,7 +329,7 @@ jobs:
             --instance-ids "${{ secrets.EC2_INSTANCE_ID }}" \
             --document-name "AWS-RunShellScript" \
             --timeout-seconds 300 \
-            --parameters 'commands=["export HOME=/root && export PATH=$PATH:/usr/local/bin:/usr/bin && bash /home/ubuntu/discord_clone/scripts/deploy.sh ${{ github.ref_name }}"]' \
+            --parameters 'commands=["export HOME=/root && export PATH=$PATH:/usr/local/bin:/usr/bin:/usr/local/aws-cli/v2/current/bin && bash /home/ubuntu/discord_clone/scripts/deploy.sh ${{ github.ref_name }}"]' \
             --query "Command.CommandId" --output text)
 
           # Poll with structured status parsing — never grep mixed output
@@ -362,7 +362,7 @@ jobs:
           done
 
       - name: Notify on failure
-        if: failure()
+        if: failure() && secrets.DEPLOY_WEBHOOK_URL != ''
         run: |
           curl -H "Content-Type: application/json" \
             -d '{"content": "**Deploy FAILED:** `${{ github.ref_name }}` — [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"}' \


### PR DESCRIPTION
## Summary
- Add `/usr/local/aws-cli/v2/current/bin` to the `PATH` export in both SSM command strings ("Sync config files" and "Deploy via SSM") so the `aws` CLI is found on the EC2 instance
- Guard the "Notify on failure" step so it skips when `DEPLOY_WEBHOOK_URL` is unset, preventing a `curl` malformed URL error

## Test plan
- [ ] Trigger a release and verify the deploy-server job passes the "Sync config files" step
- [ ] Verify the "Deploy via SSM" step completes successfully
- [ ] Confirm the webhook notification step is skipped cleanly when `DEPLOY_WEBHOOK_URL` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)