### PR TITLE
fix: use env var to guard webhook URL in deploy step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -362,8 +362,11 @@ jobs:
           done
 
       - name: Notify on failure
-        if: failure() && secrets.DEPLOY_WEBHOOK_URL != ''
+        if: failure()
+        env:
+          WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
         run: |
+          [ -z "$WEBHOOK_URL" ] && exit 0
           curl -H "Content-Type: application/json" \
             -d '{"content": "**Deploy FAILED:** `${{ github.ref_name }}` — [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"}' \
-            "${{ secrets.DEPLOY_WEBHOOK_URL }}"
+            "$WEBHOOK_URL"


### PR DESCRIPTION
## Summary
- The `secrets` context is not available in step-level `if:` expressions, causing a workflow validation error
- Moves the empty-URL check into the shell script via an env var so the step exits cleanly when `DEPLOY_WEBHOOK_URL` is unset

## Test plan
- [ ] Verify workflow passes GitHub Actions validation (no more `Unrecognized named-value: 'secrets'` error)
- [ ] Trigger a release without `DEPLOY_WEBHOOK_URL` set and confirm the notify step exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)