### PR TITLE
fix: replace awslogs-stream-prefix with tag option

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,8 +41,8 @@ services:
       options:
         awslogs-region: us-east-1
         awslogs-group: /discord-clone/production/app
-        awslogs-stream-prefix: app-blue
         awslogs-create-group: "true"
+        tag: "app-blue/{{ .ID }}"
         mode: "non-blocking"
         max-buffer-size: "4m"
     healthcheck:
@@ -96,8 +96,8 @@ services:
       options:
         awslogs-region: us-east-1
         awslogs-group: /discord-clone/production/app
-        awslogs-stream-prefix: app-green
         awslogs-create-group: "true"
+        tag: "app-green/{{ .ID }}"
         mode: "non-blocking"
         max-buffer-size: "4m"
     healthcheck:
@@ -159,8 +159,8 @@ services:
       options:
         awslogs-region: us-east-1
         awslogs-group: /discord-clone/production/nginx
-        awslogs-stream-prefix: nginx
         awslogs-create-group: "true"
+        tag: "nginx/{{ .ID }}"
         mode: "non-blocking"
         max-buffer-size: "4m"
 


### PR DESCRIPTION
## Summary
- Docker CE 29.x rejects `awslogs-stream-prefix` as an unknown log option
- Replace with `tag` option which serves the same purpose — identifies the service in CloudWatch log stream names
- Affects app-blue, app-green, and nginx services

## Test plan
- [ ] Verify containers start without log driver errors
- [ ] Check CloudWatch log streams are created with service-identifiable names

🤖 Generated with [Claude Code](https://claude.com/claude-code)