### PR TITLE
fix: remove dotenv runtime import for production

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx watch --env-file=../.env src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "vitest run",
@@ -20,7 +20,6 @@
     "@fastify/websocket": "^11.2.0",
     "bcrypt": "^6.0.0",
     "discord-clone-shared": "*",
-    "dotenv": "^17.3.1",
     "drizzle-orm": "^0.45.1",
     "fastify": "^5.7.0",
     "fastify-plugin": "^5.1.0",
@@ -31,6 +30,7 @@
   },
   "devDependencies": {
     "@electric-sql/pglite": "^0.3.15",
+    "dotenv": "^17.3.1",
     "@types/bcrypt": "^6.0.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/libsodium-wrappers": "^0.8.2",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,11 +1,3 @@
-import dotenv from 'dotenv';
-import path from 'path';
-import { fileURLToPath } from 'url';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-dotenv.config({ path: path.resolve(__dirname, '../../.env') });
-
 async function start(): Promise<void> {
   // Generate GROUP_ENCRYPTION_KEY before any modules read it
   if (!process.env.GROUP_ENCRYPTION_KEY) {


### PR DESCRIPTION
## Summary
- Remove `dotenv` import from `server/src/index.ts` — production env vars are injected by Docker Compose, so dotenv is unnecessary and causes `ERR_MODULE_NOT_FOUND` in the container
- Move `dotenv` to `devDependencies` so it's excluded from the production image
- Use Node's built-in `--env-file` flag in the dev script to load `.env` locally

## Test plan
- [ ] `npm run dev -w server` still loads `.env` variables locally
- [ ] Docker image builds and container starts without `ERR_MODULE_NOT_FOUND`
- [ ] Deploy completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)