### PR TITLE
fix: skip duplicate migration on cold start deploy

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -89,10 +89,13 @@ done
 
 # 5. Run database migrations on new slot against Supabase (old slot still serves traffic)
 # Both slots can safely connect to Supabase concurrently — Postgres handles concurrent access.
-if ! docker compose exec -T "app-$NEW" node server/dist/scripts/migrate.js 2>&1; then
-  echo "FATAL: database migration failed on app-$NEW (Supabase)"
-  docker compose stop "app-$NEW"
-  exit 1
+# Skip if already ran during cold start (step 3a)
+if [ "$ACTIVE" != "none" ]; then
+  if ! docker compose exec -T "app-$NEW" node server/dist/scripts/migrate.js 2>&1; then
+    echo "FATAL: database migration failed on app-$NEW (Supabase)"
+    docker compose stop "app-$NEW"
+    exit 1
+  fi
 fi
 
 # 6. Drain old slot — signal clients to reconnect


### PR DESCRIPTION
## Summary
- On cold start, migrations already run in step 3a (before health check)
- Step 5 was re-running migrations unnecessarily, causing a failure
- Skip step 5 when `ACTIVE=none` (cold start) since migrations already completed

## Test plan
- [ ] Cold start deploy runs migrations once in step 3a and skips step 5
- [ ] Warm deploy still runs migrations in step 5 as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)