### PR TITLE
fix: quiet docker compose output to prevent SSM IPC timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,6 +351,12 @@ jobs:
                 break ;;
               Failed|TimedOut|Cancelled)
                 echo "Deploy failed with status: $STATUS"
+                echo "=== STDOUT ==="
+                aws ssm get-command-invocation \
+                  --command-id "$COMMAND_ID" \
+                  --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
+                  --query "StandardOutputContent" --output text
+                echo "=== STDERR ==="
                 aws ssm get-command-invocation \
                   --command-id "$COMMAND_ID" \
                   --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -54,11 +54,11 @@ else
 fi
 echo "Active: $ACTIVE -> Deploying: $NEW"
 
-# 2. Pull only the target slot image
-docker compose pull "app-$NEW"
+# 2. Pull only the target slot image (quiet to avoid SSM output buffer overflow)
+docker compose pull -q "app-$NEW"
 
 # 3. Start new slot (no traffic routed yet — nginx still points at old slot)
-docker compose --profile deploy up -d "app-$NEW"
+docker compose --profile deploy up -d "app-$NEW" 2>&1 | tail -5
 
 # 3a. On cold start, run migrations before health check (tables may not exist yet)
 if [ "$ACTIVE" = "none" ]; then


### PR DESCRIPTION
## Summary
- Docker compose pull/up progress bars produce excessive output that overwhelms the SSM agent's IPC buffer, causing `document process failed unexpectedly: ipc messaging received timeout signal`
- Use `docker compose pull -q` and pipe `up` output through `tail -5`
- Print both stdout and stderr on deploy failure for better debugging visibility

## Test plan
- [ ] Deploy completes without SSM IPC timeout
- [ ] On failure, workflow logs show both stdout and stderr from the deploy script

🤖 Generated with [Claude Code](https://claude.com/claude-code)