### PR TITLE
fix: skip Trivy check update to avoid git clone failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,10 @@ jobs:
           severity: 'CRITICAL,HIGH'
           exit-code: '1'
           ignore-unfixed: true
+          skip-setup-trivy: false
+        env:
+          TRIVY_SKIP_CHECK_UPDATE: true
+          TRIVY_DISABLE_VEX_NOTICE: true
 
   publish-release:
     needs: [detect-changes, build-electron]


### PR DESCRIPTION
## Summary
- Trivy action v0.34.1 tries to git clone its checks/policies repo, which fails with `fatal: couldn't find remote ref refs/heads/main` in shallow-clone CI environments
- Set `TRIVY_SKIP_CHECK_UPDATE` and `TRIVY_DISABLE_VEX_NOTICE` env vars to skip the git operation while still running the vulnerability scan

## Test plan
- [ ] build-server-image job completes the Trivy scan without git errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)