### PR TITLE
fix: install trivy to user-writable path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,8 @@ jobs:
 
       - name: Scan image for vulnerabilities
         run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b $HOME/.local/bin
+          export PATH="$HOME/.local/bin:$PATH"
           trivy image \
             --severity CRITICAL,HIGH \
             --exit-code 1 \


### PR DESCRIPTION
## Summary
- `/usr/local/bin` requires sudo on GitHub runners, causing the trivy install to silently fail
- Install to `~/.local/bin` and add to PATH

## Test plan
- [ ] build-server-image vulnerability scan runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)