### PR TITLE
ci: move Trivy scan from release to PR workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,36 @@ jobs:
           docker compose config --quiet
           rm .env
 
+  trivy-scan:
+    runs-on: ubuntu-latest
+    needs: [check-paths]
+    if: needs.check-paths.outputs.server == 'true' || needs.check-paths.outputs.shared == 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.12.0
+
+      - name: Build server image for scanning
+        uses: docker/build-push-action@v6.19.2
+        with:
+          context: .
+          file: server/Dockerfile
+          push: false
+          load: true
+          tags: discord-clone-server:ci-scan
+
+      - name: Scan image for vulnerabilities
+        run: |
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b $HOME/.local/bin
+          export PATH="$HOME/.local/bin:$PATH"
+          trivy image \
+            --severity CRITICAL,HIGH \
+            --exit-code 1 \
+            --ignore-unfixed \
+            --format table \
+            discord-clone-server:ci-scan
+
   terraform-validate:
     runs-on: ubuntu-latest
     needs: [check-paths]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,17 +175,6 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/aidenwoodside/discord-clone-server:buildcache
           cache-to: type=registry,ref=ghcr.io/aidenwoodside/discord-clone-server:buildcache,mode=max
 
-      - name: Scan image for vulnerabilities
-        run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b $HOME/.local/bin
-          export PATH="$HOME/.local/bin:$PATH"
-          trivy image \
-            --severity CRITICAL,HIGH \
-            --exit-code 1 \
-            --ignore-unfixed \
-            --format table \
-            ghcr.io/aidenwoodside/discord-clone-server:${{ github.sha }}
-
   publish-release:
     needs: [detect-changes, build-electron]
     if: |


### PR DESCRIPTION
## Summary
- Removed Trivy vulnerability scan from the release workflow's `build-server-image` job
- Added a new `trivy-scan` job to the CI (PR) workflow that builds the server Docker image locally and scans it
- Scan only runs when server or shared files change, matching existing path-filter logic

## Test plan
- [ ] Open a PR touching server files and verify the `trivy-scan` job runs
- [ ] Open a PR touching only client files and verify the `trivy-scan` job is skipped
- [ ] Push a release tag and verify the release workflow no longer includes a scan step

🤖 Generated with [Claude Code](https://claude.com/claude-code)