### PR TITLE
ci: add workflow_dispatch to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ name: Release
 on:
   push:
     tags: ['v*']
+  workflow_dispatch:
 
 # Deny all permissions by default — each job declares its own
 permissions: {}


### PR DESCRIPTION
## Summary
- Added `workflow_dispatch` trigger to the release workflow
- Enables manual releases via the "Run workflow" button in GitHub Actions UI

## Test plan
- [ ] Navigate to Actions > Release > "Run workflow" and confirm the button is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)