### PR TITLE
fix(ci): make release workflow compatible with manual dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ concurrency:
 
 jobs:
   validate-version:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -46,6 +47,7 @@ jobs:
 
   detect-changes:
     needs: [validate-version]
+    if: always() && (needs.validate-version.result == 'success' || needs.validate-version.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -101,7 +103,7 @@ jobs:
           echo "Results: client_changed=$CLIENT, server_changed=$SERVER"
 
   build-electron:
-    needs: [validate-version, detect-changes]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.client_changed == 'true'
     strategy:
       fail-fast: false
@@ -144,7 +146,7 @@ jobs:
           if-no-files-found: error
 
   build-server-image:
-    needs: [validate-version, detect-changes]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.server_changed == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -180,6 +182,7 @@ jobs:
     needs: [detect-changes, build-electron]
     if: |
       always() &&
+      github.event_name != 'workflow_dispatch' &&
       needs.detect-changes.outputs.client_changed == 'true' &&
       needs.build-electron.result == 'success'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Skip `validate-version` on `workflow_dispatch` (no v* tag to compare against)
- Add `if: always()` to `detect-changes` so it runs when `validate-version` is skipped
- Remove `validate-version` as a dependency from `build-electron` and `build-server-image`
- Skip `publish-release` on manual dispatch since there's no GitHub release to manage

On manual dispatch, `github.ref_name` is `main` instead of a tag — this caused `validate-version` to fail comparing `main` != `v0.99.118`, blocking the entire pipeline.

## Test plan
- [ ] Trigger manual dispatch from Actions UI and verify all jobs proceed
- [ ] Push a `v*` tag and verify `validate-version` still runs and enforces the check

🤖 Generated with [Claude Code](https://claude.com/claude-code)