### PR TITLE
fix: start nginx on cold start before config validation

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -130,6 +130,12 @@ NGINX_TEMPLATE="$DEPLOY_DIR/docker/nginx/nginx.conf.template"
 cp "$NGINX_CONF" "$NGINX_CONF.bak"
 sed "s/{{UPSTREAM}}/app-$NEW:$NEW_PORT/" "$NGINX_TEMPLATE" > "$NGINX_CONF"
 
+# 7a. Start nginx if not already running (cold start)
+if ! docker compose ps nginx --status running -q 2>/dev/null | grep -q .; then
+  docker compose up -d nginx 2>&1 | tail -5
+  sleep 2
+fi
+
 # 8. Validate nginx config before reload
 if ! docker compose exec -T nginx nginx -t 2>&1; then
   echo "FATAL: nginx config validation failed — restoring backup"


### PR DESCRIPTION
## Summary
- Start nginx container if not already running before attempting `nginx -t` validation
- Fixes cold start deployments where only the app slot was started but nginx was not

The deploy script's config validation (`docker compose exec -T nginx nginx -t`) fails on cold starts because nginx hasn't been started yet — only the app slot container is brought up.

## Test plan
- [ ] Run a manual deployment and verify nginx starts successfully on cold start
- [ ] Verify normal blue/green swap deployments still work (nginx already running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)