### PR TITLE
fix: use --no-deps when starting nginx during deploy

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -130,9 +130,9 @@ NGINX_TEMPLATE="$DEPLOY_DIR/docker/nginx/nginx.conf.template"
 cp "$NGINX_CONF" "$NGINX_CONF.bak"
 sed "s/{{UPSTREAM}}/app-$NEW:$NEW_PORT/" "$NGINX_TEMPLATE" > "$NGINX_CONF"
 
-# 7a. Start nginx if not already running (cold start)
+# 7a. Start nginx if not already running
 if ! docker compose ps nginx --status running -q 2>/dev/null | grep -q .; then
-  docker compose up -d nginx 2>&1 | tail -5
+  docker compose up -d --no-deps nginx 2>&1 | tail -5
   sleep 2
 fi
 


### PR DESCRIPTION
## Summary
- Use `--no-deps` flag when starting nginx in the deploy script
- Prevents Docker Compose from re-evaluating `depends_on: service_healthy` which races with the app container's 30s `start_period` healthcheck

The deploy script already validates app health via curl before starting nginx, so the Compose dependency guard is redundant at this point and causes cold start failures.

## Test plan
- [ ] Run a manual deployment (cold start) and verify nginx starts successfully
- [ ] Verify normal blue/green swap deployments still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)