### PR TITLE
fix: bootstrap nginx with HTTP-only when SSL certs missing

### DIFF
--- a/docker/nginx/nginx.http-only.conf.template
+++ b/docker/nginx/nginx.http-only.conf.template
@@ -1,0 +1,58 @@
+upstream app_backend {
+    server {{UPSTREAM}};  # Managed by scripts/deploy.sh — do not edit manually
+}
+
+# Rate limiting zone for API requests
+limit_req_zone $binary_remote_addr zone=api:10m rate=60r/m;
+
+# HTTP only — used when SSL certs are not yet provisioned
+server {
+    listen 80;
+    server_name _;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    # Drain endpoint — block external access (deploy script calls via 127.0.0.1)
+    location /api/drain {
+        deny all;
+    }
+
+    # API proxy
+    location /api/ {
+        limit_req zone=api burst=20 nodelay;
+
+        proxy_pass http://app_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # WebSocket proxy
+    location /ws {
+        proxy_pass http://app_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+    }
+
+    # Downloads — serve app installers
+    location /downloads/ {
+        alias /usr/share/nginx/downloads/;
+        autoindex off;
+    }
+
+    # Landing page (invite URLs and downloads)
+    location / {
+        root /usr/share/nginx/landing;
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -127,13 +127,42 @@ fi
 # 7. Switch nginx upstream via template (not in-place sed)
 NGINX_CONF="$DEPLOY_DIR/docker/nginx/nginx.conf"
 NGINX_TEMPLATE="$DEPLOY_DIR/docker/nginx/nginx.conf.template"
+NGINX_HTTP_TEMPLATE="$DEPLOY_DIR/docker/nginx/nginx.http-only.conf.template"
+CERT_PATH="$DEPLOY_DIR/data/certs/live/discweeds.com/fullchain.pem"
 cp "$NGINX_CONF" "$NGINX_CONF.bak"
-sed "s/{{UPSTREAM}}/app-$NEW:$NEW_PORT/" "$NGINX_TEMPLATE" > "$NGINX_CONF"
+
+NEED_CERTS=false
+if [ ! -f "$CERT_PATH" ]; then
+  echo "SSL certs not found — bootstrapping nginx with HTTP-only config"
+  NEED_CERTS=true
+  sed "s/{{UPSTREAM}}/app-$NEW:$NEW_PORT/" "$NGINX_HTTP_TEMPLATE" > "$NGINX_CONF"
+else
+  sed "s/{{UPSTREAM}}/app-$NEW:$NEW_PORT/" "$NGINX_TEMPLATE" > "$NGINX_CONF"
+fi
 
 # 7a. Start nginx if not already running
 if ! docker compose ps nginx --status running -q 2>/dev/null | grep -q .; then
   docker compose up -d --no-deps nginx 2>&1 | tail -5
   sleep 2
+fi
+
+# 7b. If certs were missing, obtain them via certbot then switch to HTTPS config
+if [ "$NEED_CERTS" = "true" ]; then
+  echo "Requesting SSL certificate via certbot..."
+  docker compose run --rm certbot certonly \
+    --webroot -w /var/www/certbot \
+    -d discweeds.com \
+    --non-interactive --agree-tos \
+    --email admin@discweeds.com 2>&1
+
+  if [ ! -f "$CERT_PATH" ]; then
+    echo "FATAL: certbot failed to obtain SSL certificate"
+    docker compose stop "app-$NEW"
+    exit 1
+  fi
+
+  echo "SSL certs obtained — switching to HTTPS config"
+  sed "s/{{UPSTREAM}}/app-$NEW:$NEW_PORT/" "$NGINX_TEMPLATE" > "$NGINX_CONF"
 fi
 
 # 8. Validate nginx config before reload


### PR DESCRIPTION
## Summary
- Added `nginx.http-only.conf.template` — serves HTTP traffic and ACME challenges without requiring SSL certs
- Deploy script now checks for SSL cert existence before starting nginx
- If certs are missing: starts nginx HTTP-only, runs certbot to obtain certs, then switches to full HTTPS config and reloads
- If certs exist: uses the full HTTPS template as before (no behavior change)

Fixes nginx crash-loop on fresh instances where SSL certs haven't been provisioned yet.

## Test plan
- [ ] Deploy to a fresh instance without certs — verify certbot obtains certs and nginx switches to HTTPS
- [ ] Deploy to an instance with existing certs — verify no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)