### PR TITLE
fix: force-remove crash-looping nginx before recreating

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -140,8 +140,10 @@ else
   sed "s/{{UPSTREAM}}/app-$NEW:$NEW_PORT/" "$NGINX_TEMPLATE" > "$NGINX_CONF"
 fi
 
-# 7a. Start nginx if not already running
+# 7a. Ensure nginx is running with the current config
 if ! docker compose ps nginx --status running -q 2>/dev/null | grep -q .; then
+  # Remove any crash-looping container so up creates a fresh one with new config
+  docker compose rm -sf nginx 2>/dev/null || true
   docker compose up -d --no-deps nginx 2>&1 | tail -5
   sleep 2
 fi


### PR DESCRIPTION
## Summary
- Force stop and remove nginx container before starting fresh when it's not in a running state
- Fixes the case where a previous failed deploy left nginx in a crash-loop (`restart: unless-stopped` keeps restarting it with the old broken config), and `docker compose up -d` reuses the existing container instead of creating a new one with the updated config

## Test plan
- [ ] Deploy after a failed deploy that left nginx crash-looping — verify nginx starts cleanly with new config

🤖 Generated with [Claude Code](https://claude.com/claude-code)