### PR TITLE
fix: detect crash-looping nginx and make post-switchover check fatal

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -170,20 +170,28 @@ if ! docker compose ps nginx --status running -q 2>/dev/null | grep -q .; then
   NGINX_WAS_DOWN=true
   echo "nginx not running — starting fresh"
   docker compose rm -sf nginx 2>/dev/null || true
+  sleep 1
   docker compose up -d --no-deps nginx 2>&1 | tail -5
 
-  # Wait for nginx to stabilize (not just "Started" — actually running)
+  # Wait for nginx to stabilize — a crash-looping container briefly shows "running"
+  # between restarts, so require CONSECUTIVE successes to confirm it's genuinely up.
   NGINX_UP=false
-  for i in $(seq 1 5); do
+  CONSECUTIVE=0
+  for i in $(seq 1 10); do
     sleep 2
     if docker compose ps nginx --status running -q 2>/dev/null | grep -q .; then
-      NGINX_UP=true
-      break
+      CONSECUTIVE=$((CONSECUTIVE + 1))
+      if [ "$CONSECUTIVE" -ge 3 ]; then
+        NGINX_UP=true
+        break
+      fi
+    else
+      CONSECUTIVE=0
     fi
   done
   if [ "$NGINX_UP" != "true" ]; then
-    echo "FATAL: nginx failed to start — container logs:"
-    docker compose logs --tail=30 nginx 2>&1 || true
+    echo "FATAL: nginx failed to stabilize — container logs:"
+    docker compose logs --tail=50 nginx 2>&1 || true
     cp "$NGINX_CONF.bak" "$NGINX_CONF"
     docker compose stop "app-$NEW"
     exit 1
@@ -230,10 +238,19 @@ if [ "$NGINX_WAS_DOWN" != "true" ]; then
   fi
 fi
 
-# 9. Post-switchover verification — verify nginx can reach new slot via Docker DNS
+# 9. Post-switchover verification — nginx MUST be able to reach the new slot.
+# If this fails, the site is down. Abort before stopping the old slot.
 sleep 2
 if ! docker compose exec -T nginx wget --spider -q "http://app-$NEW:$NEW_PORT/api/health" 2>&1; then
-  echo "WARNING: post-switchover health check via nginx->app-$NEW failed — verify manually"
+  echo "FATAL: post-switchover health check failed — nginx cannot reach app-$NEW"
+  echo "Capturing nginx logs:"
+  docker compose logs --tail=30 nginx 2>&1 || true
+  echo "Restoring previous config and keeping old slot running..."
+  cp "$NGINX_CONF.bak" "$NGINX_CONF"
+  # Try to reload nginx with old config so old slot can still serve traffic
+  docker compose exec -T nginx nginx -s reload 2>/dev/null || true
+  docker compose stop "app-$NEW"
+  exit 1
 fi
 
 # 10. Stop old slot


### PR DESCRIPTION
## Summary
- **Fix stabilization race condition**: A crash-looping container briefly shows "running" status between crashes. The single-check passed during this window. Now requires **3 consecutive** "running" checks (6s sustained) to confirm stability.
- **Make post-switchover check fatal**: Previously a WARNING that let the deploy continue and stop the old slot — leaving the site down. Now aborts, captures nginx logs, restores the previous config, and keeps the old slot running.
- **Add 1s delay between `rm -sf` and `up -d`** to ensure port release before rebinding.

## Context
The v0.99.138 deploy (PR #76) reported "Deploy complete" but the site was unreachable. The deploy logs show nginx started but immediately crash-looped. The stabilization check caught a brief "running" window and proceeded. The post-switchover health check failed but was only a WARNING, so the deploy stopped the old slot anyway.

## Test plan
- [ ] Deploy when nginx crash-loops: stabilization check detects it after 10 iterations (no consecutive "running" windows), dumps container logs, aborts deploy
- [ ] Deploy when post-switchover check fails: deploy aborts, restores old config, reloads nginx with previous upstream, keeps old slot running
- [ ] Normal deploy (nginx healthy): 3 consecutive checks pass within ~6s, deploy completes as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)