### PR TITLE
fix: use short port syntax for UDP range in Swarm stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,11 +29,8 @@ services:
         published: 3001
         protocol: tcp
         mode: host
-      # mediasoup RTP — host mode bypasses Swarm ingress mesh (single-node, no routing overhead)
-      - target: 40000-40049
-        published: 40000-40049
-        protocol: udp
-        mode: host
+      # mediasoup RTP — short syntax required for port ranges (ingress mode on single-node is fine)
+      - "40000-40049:40000-40049/udp"
     stop_grace_period: 30s
     read_only: true
     tmpfs:


### PR DESCRIPTION
## Summary
- Fixes deploy failure (`services.app.ports.1.target must be a integer`) caused by using Docker Compose long port syntax with a port range for mediasoup UDP ports
- Docker Swarm long port syntax requires `target` to be an integer — port ranges (`40000-40049`) are only valid in short string syntax
- Ingress mode on a single-node Swarm is fine — IPVS just does a local forward with negligible overhead

## Test plan
- [ ] Merge and verify the release workflow's deploy-server job succeeds
- [ ] Confirm mediasoup WebRTC calls still work (UDP 40000-40049 reachable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)