### PR TITLE
fix: add CHOWN/SETUID/SETGID capabilities to nginx in Swarm stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,9 @@ services:
       - ALL
     cap_add:
       - NET_BIND_SERVICE
+      - CHOWN
+      - SETUID
+      - SETGID
     volumes:
       - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
       - ./docker/nginx/landing:/usr/share/nginx/landing:ro


### PR DESCRIPTION
## Summary
- nginx crashes on startup in Swarm with `cap_drop: ALL` because it needs to `chown` cache directories (`/var/cache/nginx/client_temp`) to the nginx user (uid 101) and drop privileges from root to worker processes
- Adds `CHOWN`, `SETUID`, `SETGID` capabilities alongside existing `NET_BIND_SERVICE`

## Test plan
- [ ] Deploy stack: `docker stack deploy -c docker-compose.yml --with-registry-auth discord-clone`
- [ ] Verify `docker service ls` shows nginx at 1/1 replicas
- [ ] Verify HTTPS accessible at discweeds.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)