### PR TITLE
fix: prevent voice channel leave/rejoin when clicking current channel

### DIFF
--- a/client/src/renderer/src/features/channels/ChannelItem.test.tsx
+++ b/client/src/renderer/src/features/channels/ChannelItem.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, useLocation } from 'react-router';
 import { ChannelItem } from './ChannelItem';
+import { useVoiceStore } from '../../stores/useVoiceStore';
 
 let capturedPathname = '';
 
@@ -15,6 +16,7 @@ function LocationSpy() {
 beforeEach(() => {
   vi.clearAllMocks();
   capturedPathname = '';
+  useVoiceStore.setState({ currentChannelId: null });
 });
 
 function renderItem(props: { type: 'text' | 'voice'; isActive?: boolean }) {
@@ -70,5 +72,16 @@ describe('ChannelItem', () => {
   it('renders voice channel with correct button', () => {
     renderItem({ type: 'voice' });
     expect(screen.getByRole('button', { name: /test-channel/i })).toBeInTheDocument();
+  });
+
+  it('does not call joinChannel when already in the same voice channel', async () => {
+    const joinSpy = vi.fn();
+    useVoiceStore.setState({ currentChannelId: 'ch-1', joinChannel: joinSpy } as any);
+
+    renderItem({ type: 'voice' });
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button'));
+
+    expect(joinSpy).not.toHaveBeenCalled();
   });
 });

--- a/client/src/renderer/src/features/channels/ChannelItem.tsx
+++ b/client/src/renderer/src/features/channels/ChannelItem.tsx
@@ -13,13 +13,14 @@ interface ChannelItemProps {
 export function ChannelItem({ channel, isActive }: ChannelItemProps): React.ReactNode {
   const navigate = useNavigate();
   const joinChannel = useVoiceStore((s) => s.joinChannel);
+  const currentChannelId = useVoiceStore((s) => s.currentChannelId);
   const userId = useAuthStore((s) => s.user?.id);
   const Icon = channel.type === 'text' ? Hash : Volume2;
 
   const handleClick = () => {
     if (channel.type === 'text') {
       navigate(`/app/channels/${channel.id}`);
-    } else if (userId) {
+    } else if (userId && channel.id !== currentChannelId) {
       joinChannel(channel.id, userId);
     }
   };

--- a/client/src/renderer/src/stores/useVoiceStore.test.ts
+++ b/client/src/renderer/src/stores/useVoiceStore.test.ts
@@ -153,6 +153,21 @@ describe('useVoiceStore', () => {
       expect(voiceService.cleanupMedia).toHaveBeenCalled();
     });
 
+    it('is a no-op when joining the same channel already connected to', async () => {
+      useVoiceStore.setState({
+        currentChannelId: 'voice-ch-1',
+        currentUserId: 'my-user-id',
+        connectionState: 'connected',
+      });
+
+      await useVoiceStore.getState().joinChannel('voice-ch-1', 'my-user-id');
+
+      expect(mockJoin).not.toHaveBeenCalled();
+      expect(mockLeave).not.toHaveBeenCalled();
+      expect(useVoiceStore.getState().currentChannelId).toBe('voice-ch-1');
+      expect(useVoiceStore.getState().connectionState).toBe('connected');
+    });
+
     it('leaves current channel before joining new one', async () => {
       // Set up as already connected
       useVoiceStore.setState({

--- a/client/src/renderer/src/stores/useVoiceStore.ts
+++ b/client/src/renderer/src/stores/useVoiceStore.ts
@@ -63,6 +63,11 @@ export const useVoiceStore = create<VoiceState>((set, get) => ({
   joinChannel: async (channelId: string, userId: string) => {
     const state = get();
 
+    // No-op if already in the requested channel
+    if (state.currentChannelId === channelId) {
+      return;
+    }
+
     // Leave current channel first if already in one
     if (state.currentChannelId) {
       await get().leaveChannel();


### PR DESCRIPTION
## Summary
- Adds a guard in `ChannelItem.tsx` to skip `joinChannel` when the clicked voice channel matches `currentChannelId`
- Adds a defensive early return in `useVoiceStore.joinChannel` so no caller can trigger a leave/rejoin on the same channel
- Adds tests for both guards (79/79 passing)

## Test plan
- [x] Click a voice channel to join — works as before
- [x] Click the same voice channel again — nothing happens (no leave/rejoin)
- [x] Click a different voice channel while connected — leaves old, joins new
- [x] All existing + new unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)